### PR TITLE
#40 Bump versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lombok.version>1.18.34</lombok.version>
-        <checkstyle.version>3.3.1</checkstyle.version>
-        <spring-boot.version>3.3.1</spring-boot.version>
+        <lombok.version>1.18.38</lombok.version>
+        <checkstyle.version>3.6.0</checkstyle.version>
+        <spring-boot.version>3.5.5</spring-boot.version>
     </properties>
     <dependencies>
         <dependency>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -138,7 +138,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.3.1</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -151,7 +151,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.6.3</version>
+                        <version>3.11.3</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -164,7 +164,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.2.8</version>
                         <configuration>
                             <gpgArguments>
                                 <arg>--pinentry-mode</arg>
@@ -184,7 +184,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>1.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the versions of various dependencies and plugins in the `pom.xml` file to enhance compatibility and functionality.

### Detailed summary
- Updated `lombok.version` from `1.18.34` to `1.18.38`
- Updated `checkstyle.version` from `3.3.1` to `3.6.0`
- Updated `spring-boot.version` from `3.3.1` to `3.5.5`
- Updated `maven-surefire-plugin` version from `3.2.5` to `3.5.3`
- Updated `maven-source-plugin` version from `3.2.1` to `3.3.1`
- Updated `maven-javadoc-plugin` version from `3.6.3` to `3.11.3`
- Updated `maven-gpg-plugin` version from `3.0.1` to `3.2.8`
- Updated `nexus-staging-maven-plugin` version from `1.6.13` to `1.7.0`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->