### PR TITLE
#43 Bump versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
         </developerConnection>
         <url>https://github.com/ilyalisov/spring-boot-starter-mail</url>
     </scm>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.1</version>
+        <relativePath/>
+    </parent>
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -45,34 +51,28 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.38</lombok.version>
         <checkstyle.version>3.6.0</checkstyle.version>
-        <spring-boot.version>3.5.5</spring-boot.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
-            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-freemarker</artifactId>
-            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
-            <version>${lombok.version}</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `pom.xml` file to change the Spring Boot version and restructure the dependencies. It introduces a parent POM and removes the version placeholders for several dependencies.

### Detailed summary
- Added a `<parent>` section with `groupId`, `artifactId`, and `version` for `spring-boot-starter-parent`.
- Updated the Spring Boot version to `3.3.1`.
- Removed the `${spring-boot.version}` placeholders from several dependencies.
- Kept the `lombok.version` as `1.18.38`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->