### PR TITLE
#25 Implement bean configuration of MailTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # Spring Boot Starter Mail
 
-[![Lines-of-Code](https://tokei.rs/b1/github/ilyalisov/spring-boot-starter-mail)](https://github.com/ilyalisov/spring-boot-starter-mail)
-[![Hits-of-Code](https://hitsofcode.com/github/ilyalisov/spring-boot-starter-mail?branch=master)](https://hitsofcode.com/github/ilyalisov/spring-boot-starter-mail/view?branch=master)
 [![mvn](https://github.com/ilyalisov/spring-boot-starter-mail/actions/workflows/maven-build.yml/badge.svg)](https://github.com/ilyalisov/spring-boot-starter-mail/actions/workflows/maven-build.yml)
-
 [![codecov](https://codecov.io/gh/IlyaLisov/spring-boot-starter-mail/graph/badge.svg?token=OJR6TFQ2qr)](https://codecov.io/gh/IlyaLisov/spring-boot-starter-mail)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.3.1-brightgreen.svg)](https://spring.io/projects/spring-boot)
 
 This repository is an open-source Java library for fast and convenient using of
 MailSender in your Spring Boot applications.
 
-## Content:
+## Table of contents:
 
 * [How to use](#how-to-use)
     * [Prerequisites](#prerequisites)
@@ -17,7 +16,8 @@ MailSender in your Spring Boot applications.
     * [Send email](#send-email)
     * [Send email to many people](#send-email-to-many-people)
     * [Templates](#templates)
-* [How to contribute](#how-to-contribute)
+* [License](#license)
+* [Contribution](#contribution)
 
 ## How to use
 
@@ -103,6 +103,13 @@ just plain text.
 
 After startup, service will load all templates from `templates` directory and
 store them in memory. You can use `MailService` bean in your services.
+
+You can provide templates via `MailTemplate` beans. They will be added to
+template list from `application.yaml` at the startup.
+
+**WARNING:** Mail templates from `application.yaml` would overwrite mail
+templates from beans. This allows you to fix templates without rebuilding a
+project.
 
 ### Send email
 
@@ -326,7 +333,17 @@ This template has some variables:
   HTML tags, so you can use HTML tags in your email body
 * `buttonOpenText` - text of the button
 
-## How to contribute
+## License
 
-See active issues
-at [issues page](https://github.com/ilyalisov/spring-boot-starter-mail/issues)
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE)
+file for details.
+
+## Contribution
+
+We welcome contributions! Please feel free to submit issues and enhancement
+requests.
+
+To contribute, make a fork and open a pull request. You can find
+issues [here](https://github.com/ilyalisov/spring-boot-starter-mail/issues).
+
+Make sure, you follow project's codestyle.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.ilyalisov</groupId>
     <artifactId>spring-boot-starter-mail</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Mail service for Spring Boot applications.</description>
     <url>https://github.com/ilyalisov/spring-boot-starter-mail/</url>

--- a/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
+++ b/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
@@ -39,6 +39,7 @@ public class MailAutoConfiguration {
     /**
      * Creates a mail service bean.
      *
+     * @param templateBeans set of beans of MailTemplate
      * @return mail service
      */
     @Bean

--- a/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
+++ b/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
@@ -8,8 +8,6 @@ import io.github.ilyalisov.mail.service.MailService;
 import io.github.ilyalisov.mail.service.MailServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -28,48 +26,51 @@ import java.util.Properties;
 public class MailAutoConfiguration {
 
     /**
+     * MailServiceProperties for configuring MailService.
+     */
+    private final MailServiceProperties mailProperties;
+
+    /**
      * Freemarker configuration.
      */
-    @Autowired
-    private freemarker.template.Configuration freemarkerConfiguration;
+    private final freemarker.template.Configuration freemarkerConfiguration;
 
     /**
      * Creates a mail service bean.
      *
-     * @param mailProperties properties for default bean
      * @return mail service
      */
     @Bean
     @Primary
     @ConditionalOnMissingBean
-    public MailService mailService(
-            @Qualifier("mailServiceProperties")
-            final MailServiceProperties mailProperties
-    ) {
+    public MailService mailService() {
         Map<String, MailTemplate> templates = new HashMap<>();
-        for (MailTemplate template : mailProperties.getTemplates()) {
-            templates.put(template.getType(), template);
+        if (mailProperties.getTemplates() != null) {
+            for (MailTemplate template : mailProperties.getTemplates()) {
+                templates.put(template.getType(), template);
+            }
         }
-        return switch (mailProperties.getVendor().toLowerCase()) {
-            case "gmail.com" -> {
+        String vendor = mailProperties.getVendor() != null
+                ? mailProperties.getVendor().toLowerCase()
+                : "";
+        switch (vendor) {
+            case "gmail.com":
                 log.info("Using Gmail.com mail sender.");
-                yield new GoogleMailServiceImpl(
+                return new GoogleMailServiceImpl(
                         mailProperties.getUsername(),
                         mailProperties.getPassword(),
                         freemarkerConfiguration,
                         templates
                 );
-            }
-            case "mail.ru" -> {
+            case "mail.ru":
                 log.info("Using Mail.ru mail sender.");
-                yield new MailRuMailServiceImpl(
+                return new MailRuMailServiceImpl(
                         mailProperties.getUsername(),
                         mailProperties.getPassword(),
                         freemarkerConfiguration,
                         templates
                 );
-            }
-            default -> {
+            default:
                 log.warn("Mail vendor is not specified. "
                         + "Using default mail sender.");
                 JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
@@ -80,12 +81,12 @@ public class MailAutoConfiguration {
                 Properties properties = new Properties();
                 properties.putAll(mailProperties.getProperties());
                 mailSender.setJavaMailProperties(properties);
-                yield new MailServiceImpl(
+                return new MailServiceImpl(
                         freemarkerConfiguration,
                         mailSender,
                         templates
                 );
-            }
-        };
+        }
     }
+
 }

--- a/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
+++ b/src/main/java/io/github/ilyalisov/mail/MailAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -43,8 +44,15 @@ public class MailAutoConfiguration {
     @Bean
     @Primary
     @ConditionalOnMissingBean
-    public MailService mailService() {
+    public MailService mailService(
+            final List<MailTemplate> templateBeans
+    ) {
         Map<String, MailTemplate> templates = new HashMap<>();
+        if (templateBeans != null) {
+            for (MailTemplate template : templateBeans) {
+                templates.put(template.getType(), template);
+            }
+        }
         if (mailProperties.getTemplates() != null) {
             for (MailTemplate template : mailProperties.getTemplates()) {
                 templates.put(template.getType(), template);

--- a/src/main/java/io/github/ilyalisov/mail/config/MailServiceProperties.java
+++ b/src/main/java/io/github/ilyalisov/mail/config/MailServiceProperties.java
@@ -4,25 +4,117 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import java.util.List;
+import java.util.Map;
 
-@Configuration
+/**
+ * Configuration properties for custom mail service.
+ * Wraps Spring Boot's {@link MailProperties} to provide
+ * vendor-specific settings and email templates.
+ */
 @Getter
 @Setter
 @ConfigurationProperties(prefix = "spring.mail")
-public class MailServiceProperties extends MailProperties {
+public class MailServiceProperties {
 
     /**
-     * Vendor of mail service. Could be `mail.ru` or `gmail.com`.
-     * If not set, `spring.mail.*` properties are used.
+     * Base mail properties from Spring Boot.
+     */
+    @NestedConfigurationProperty
+    private MailProperties base = new MailProperties();
+
+    /**
+     * Vendor of mail service, e.g., `mail.ru` or `gmail.com`.
+     * If not set, default Spring Boot properties will be used.
      */
     private String vendor;
 
     /**
-     * List of templates for email.
+     * List of email templates used by the mail service.
      */
     private List<MailTemplate> templates;
+
+    /**
+     * Returns the mail server host.
+     *
+     * @return host of the mail server
+     */
+    public String getHost() {
+        return base.getHost();
+    }
+
+    /**
+     * Sets the mail server host.
+     *
+     * @param host host of the mail server
+     */
+    public void setHost(final String host) {
+        base.setHost(host);
+    }
+
+    /**
+     * Returns the mail server port.
+     *
+     * @return port of the mail server
+     */
+    public Integer getPort() {
+        return base.getPort();
+    }
+
+    /**
+     * Sets the mail server port.
+     *
+     * @param port port of the mail server
+     */
+    public void setPort(final Integer port) {
+        base.setPort(port);
+    }
+
+    /**
+     * Returns the username for authentication with the mail server.
+     *
+     * @return mail server username
+     */
+    public String getUsername() {
+        return base.getUsername();
+    }
+
+    /**
+     * Sets the username for authentication with the mail server.
+     *
+     * @param username mail server username
+     */
+    public void setUsername(final String username) {
+        base.setUsername(username);
+    }
+
+    /**
+     * Returns the password for authentication with the mail server.
+     *
+     * @return mail server password
+     */
+    public String getPassword() {
+        return base.getPassword();
+    }
+
+    /**
+     * Sets the password for authentication with the mail server.
+     *
+     * @param password mail server password
+     */
+    public void setPassword(final String password) {
+        base.setPassword(password);
+    }
+
+    /**
+     * Returns additional JavaMail properties for the mail server.
+     *
+     * @return map of JavaMail properties
+     */
+    public Map<String, String> getProperties() {
+        return base.getProperties();
+    }
 
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `spring-boot-starter-mail` project, including version changes, README enhancements, and improvements to the `MailServiceProperties` and `MailAutoConfiguration` classes.

### Detailed summary
- Updated `pom.xml` version from `1.0-SNAPSHOT` to `0.0.1`.
- Enhanced `README.md` with new badges and sections for License and Contribution.
- Improved `MailServiceProperties` class to include a base `MailProperties` object.
- Added getter and setter methods for mail server properties in `MailServiceProperties`.
- Refactored `MailAutoConfiguration` to utilize `List<MailTemplate>` for templates.
- Updated logic in `mailService` method to handle vendor-specific mail services more clearly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->